### PR TITLE
Player endpoints

### DIFF
--- a/express/queries/getPlayer.js
+++ b/express/queries/getPlayer.js
@@ -1,0 +1,7 @@
+export default function getPlayer(conn, req, res) {
+  conn.connect((e) => {
+    conn.query('select * from players where pdga_no = ?', [req.params.pdga_no], (e, result) => {
+      res.json(result);
+    });
+  });
+}

--- a/express/routes/players.js
+++ b/express/routes/players.js
@@ -2,6 +2,8 @@ import express from 'express';
 import mysql from 'mysql2';
 import dotenv from 'dotenv';
 
+import getPlayer from '#express/queries/getPlayer';
+
 const router = express.Router();
 dotenv.config();
 
@@ -20,5 +22,7 @@ router.get('/', function(req, res, next) {
     });
   });
 });
+
+router.get('/:pdga_no', (req, res, next) => getPlayer(conn, req, res));
 
 export default router;


### PR DESCRIPTION
Add a player list endpoint to express server. Add a query for player-specific data at /players/:id endpoint. This allows player data to be quickly accessed by the application.