### PR TITLE
Previous result model

### DIFF
--- a/express/queries/getEventResults.js
+++ b/express/queries/getEventResults.js
@@ -1,0 +1,14 @@
+export default async function getEventResults(conn, req, callback) {
+  conn.connect(async (e) => {
+    const pdga_no = parseInt(req.params.pdga_no);
+    const event_id = req.query.event_id;
+    const query = `select event_id
+      from event_results
+      where pdga_no = ?
+      and annual_event_id = ?
+      and event_rating > 0`;
+    conn.query(query, [pdga_no, event_id], (e, result) => {
+      return callback(result);
+    });
+  });
+}

--- a/express/r_scripts/event_model.R
+++ b/express/r_scripts/event_model.R
@@ -1,0 +1,26 @@
+library(RMariaDB)
+
+readRenviron('.env')
+
+mysqlconnection <- dbConnect(
+  RMariaDB::MariaDB(),
+  dbname = Sys.getenv('MYSQL_DB_NAME'),
+  host = Sys.getenv('MYSQL_DB_HOST'),
+  port = strtoi(Sys.getenv('MYSQL_DB_PORT')),
+  user = Sys.getenv('MYSQL_DB_USERNAME'),
+  password = Sys.getenv('MYSQL_DB_PASSWORD'),
+)
+
+getPredictedScore <- function (x) {
+  query <- 'SELECT event_rating, stroke_ct
+    FROM event_results
+    WHERE annual_event_id = ?
+    AND event_rating > 0'
+  result <- dbSendQuery(mysqlconnection, query)
+  dbBind(result, list(x))
+  data.frame <- dbFetch(result)
+  dbClearResult(result)
+  dbDisconnect(mysqlconnection)
+  lmRound <- lm(stroke_ct~event_rating, data.frame)
+  return(lmRound$coefficients)
+}

--- a/express/r_scripts/model.R
+++ b/express/r_scripts/model.R
@@ -14,6 +14,8 @@ mysqlconnection <- dbConnect(
 getRounds <- function (x) {
   result <- dbSendQuery(mysqlconnection, 'SELECT round_rating, score FROM rounds')
   data.frame <- dbFetch(result)
+  dbClearResult(result)
+  dbDisconnect(mysqlconnection)
   lmRound <- lm(score~round_rating, data.frame)
   return(lmRound$coefficients)
 }

--- a/express/r_scripts/player_model.R
+++ b/express/r_scripts/player_model.R
@@ -19,3 +19,20 @@ getPredictedScore <- function (x) {
   lmRound <- lm(stroke_ct~event_rating, data.frame)
   return(lmRound$coefficients)
 }
+
+getPredictedEventScore <- function (x, y) {
+  query <- 'SELECT a.event_rating, a.stroke_ct
+    FROM event_results a
+    JOIN (
+      SELECT DISTINCT annual_event_id
+      FROM event_results
+      WHERE event_id = ?
+    ) b ON a.annual_event_id = b.annual_event_id
+    WHERE a.pdga_no = ?
+    AND event_rating > 0'
+  result <- dbSendQuery(mysqlconnection, query)
+  dbBind(result, list(y, x))
+  data.frame <- dbFetch(result)
+  lmRound <- lm(stroke_ct~event_rating, data.frame)
+  return(lmRound$coefficients)
+}

--- a/express/r_scripts/player_model.R
+++ b/express/r_scripts/player_model.R
@@ -11,7 +11,7 @@ mysqlconnection <- dbConnect(
   password = Sys.getenv('MYSQL_DB_PASSWORD'),
 )
 
-getPredictedEventScore <- function (x) {
+getPredictedScore <- function (x) {
   query <- 'SELECT event_rating, stroke_ct FROM event_results WHERE pdga_no = ? AND event_rating > 0'
   result <- dbSendQuery(mysqlconnection, query)
   dbBind(result, list(x))

--- a/express/r_scripts/player_model.R
+++ b/express/r_scripts/player_model.R
@@ -23,17 +23,13 @@ getPredictedScore <- function (x) {
 }
 
 getPredictedEventScore <- function (x, y) {
-  query <- 'SELECT a.event_rating, a.stroke_ct
-    FROM event_results a
-    JOIN (
-      SELECT DISTINCT annual_event_id
-      FROM event_results
-      WHERE event_id = ?
-    ) b ON a.annual_event_id = b.annual_event_id
-    WHERE a.pdga_no = ?
+  query <- 'SELECT event_rating, stroke_ct
+    FROM event_results
+    WHERE pdga_no = ?
+    AND annual_event_id = ?
     AND event_rating > 0'
   result <- dbSendQuery(mysqlconnection, query)
-  dbBind(result, list(y, x))
+  dbBind(result, list(x, y))
   data.frame <- dbFetch(result)
   dbClearResult(result)
   dbDisconnect(mysqlconnection)

--- a/express/r_scripts/player_model.R
+++ b/express/r_scripts/player_model.R
@@ -16,6 +16,8 @@ getPredictedScore <- function (x) {
   result <- dbSendQuery(mysqlconnection, query)
   dbBind(result, list(x))
   data.frame <- dbFetch(result)
+  dbClearResult(result)
+  dbDisconnect(mysqlconnection)
   lmRound <- lm(stroke_ct~event_rating, data.frame)
   return(lmRound$coefficients)
 }
@@ -33,6 +35,8 @@ getPredictedEventScore <- function (x, y) {
   result <- dbSendQuery(mysqlconnection, query)
   dbBind(result, list(y, x))
   data.frame <- dbFetch(result)
+  dbClearResult(result)
+  dbDisconnect(mysqlconnection)
   lmRound <- lm(stroke_ct~event_rating, data.frame)
   return(lmRound$coefficients)
 }

--- a/express/routes/players.js
+++ b/express/routes/players.js
@@ -27,11 +27,19 @@ router.get('/', function(req, res, next) {
 router.get('/:pdga_no', (req, res, next) => getPlayer(conn, req, res));
 
 router.get('/:pdga_no/model', (req, res, next) => {
-  const model = R.callMethod('./express/r_scripts/player_model.R', 'getPredictedScore', { x: parseInt(req.params.pdga_no) });
-  const result = {};
-  result[model[1]] = model[3];
-  result[model[2]] = model[4];
-  res.json(result);
+  if (req.query.event_id) {
+    const model = R.callMethod('./express/r_scripts/player_model.R', 'getPredictedEventScore', { x: parseInt(req.params.pdga_no), y: parseInt(req.query.event_id) });
+    const result = {};
+    result[model[1]] = model[3];
+    result[model[2]] = model[4];
+    res.json(result);
+  } else {
+    const model = R.callMethod('./express/r_scripts/player_model.R', 'getPredictedScore', { x: parseInt(req.params.pdga_no) });
+    const result = {};
+    result[model[1]] = model[3];
+    result[model[2]] = model[4];
+    res.json(result);
+  }
 });
 
 export default router;

--- a/express/routes/players.js
+++ b/express/routes/players.js
@@ -27,7 +27,7 @@ router.get('/', function(req, res, next) {
 router.get('/:pdga_no', (req, res, next) => getPlayer(conn, req, res));
 
 router.get('/:pdga_no/model', (req, res, next) => {
-  const model = R.callMethod('./express/r_scripts/player_model.R', 'getPredictedEventScore', { x: parseInt(req.params.pdga_no) });
+  const model = R.callMethod('./express/r_scripts/player_model.R', 'getPredictedScore', { x: parseInt(req.params.pdga_no) });
   const result = {};
   result[model[1]] = model[3];
   result[model[2]] = model[4];


### PR DESCRIPTION
Implement event specific models. This leverages the relationships between event results in the database tied together by an annual event. Choose either a player specific model or a generalized model for the event depending on whether the player has previous results at that annual event.